### PR TITLE
Fixed Wrong Method Name

### DIFF
--- a/src/Designite/SourceModel/SM_Type.java
+++ b/src/Designite/SourceModel/SM_Type.java
@@ -370,7 +370,7 @@ public class SM_Type extends SM_SourceItem implements Vertex {
 		return getParentPkg().getParentProject().getName()
 				+ "," + getParentPkg().getName()
 				+ "," + getName()
-				+ "," + name
+				+ "," + methodName
 				+ "," + metrics.getNumOfLines()
 				+ "," + metrics.getCyclomaticComplexity()
 				+ "," + metrics.getNumOfParameters()


### PR DESCRIPTION
Fixed the Problem for Same Class And Method Name in methodMetrics.csv, now method names are correct.