### PR TITLE
Fixed bug in Missing Default Smell

### DIFF
--- a/src/Designite/smells/implementationSmells/ImplementationSmellDetector.java
+++ b/src/Designite/smells/implementationSmells/ImplementationSmellDetector.java
@@ -306,10 +306,10 @@ public class ImplementationSmellDetector {
 		List<Statement> statetmentsOfSwitch = switchStatement.statements();
 		for(Statement stm : statetmentsOfSwitch) {
 			if ((stm instanceof SwitchCase) && ((SwitchCase)stm).isDefault()) {
-				return true;
+				return false;
 			}
 		}
-		return false;			
+		return true;			
 	}
 	
 	public List<ImplementationCodeSmell> getSmells() {


### PR DESCRIPTION
The switchIsMissingDefault() method should return true when a default case is missing, and false when it's present. 